### PR TITLE
feat(pkg/stanza/operator/input/windows): add support for XML queries

### DIFF
--- a/pkg/stanza/operator/input/windows/config_all.go
+++ b/pkg/stanza/operator/input/windows/config_all.go
@@ -37,6 +37,7 @@ type Config struct {
 	SuppressRenderingInfo bool          `mapstructure:"suppress_rendering_info,omitempty"`
 	ExcludeProviders      []string      `mapstructure:"exclude_providers,omitempty"`
 	Remote                RemoteConfig  `mapstructure:"remote,omitempty"`
+	Query                 *string       `mapstructure:"query,omitempty"`
 }
 
 // RemoteConfig is the configuration for a remote server.

--- a/pkg/stanza/operator/input/windows/config_windows.go
+++ b/pkg/stanza/operator/input/windows/config_windows.go
@@ -24,8 +24,12 @@ func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, erro
 		return nil, err
 	}
 
-	if c.Channel == "" {
-		return nil, fmt.Errorf("missing required `channel` field")
+	if c.Channel == "" && c.Query == nil {
+		return nil, fmt.Errorf("either `channel` or `query` must be set")
+	}
+
+	if c.Channel != "" && c.Query != nil {
+		return nil, fmt.Errorf("either `channel` or `query` must be set, but not both")
 	}
 
 	if c.MaxReads < 1 {
@@ -51,6 +55,7 @@ func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, erro
 		raw:              c.Raw,
 		excludeProviders: excludeProvidersSet(c.ExcludeProviders),
 		remote:           c.Remote,
+		query:            c.Query,
 	}
 	input.startRemoteSession = input.defaultStartRemoteSession
 

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -26,6 +26,7 @@ type Input struct {
 	bookmark            Bookmark
 	buffer              *Buffer
 	channel             string
+	query               *string
 	maxReads            int
 	startAt             string
 	raw                 bool
@@ -131,7 +132,7 @@ func (i *Input) Start(persister operator.Persister) error {
 		subscription = NewRemoteSubscription(i.remote.Server)
 	}
 
-	if err := subscription.Open(i.startAt, uintptr(i.remoteSessionHandle), i.channel, i.bookmark); err != nil {
+	if err := subscription.Open(i.startAt, uintptr(i.remoteSessionHandle), i.channel, i.query, i.bookmark); err != nil {
 		if isNonTransientError(err) {
 			if i.isRemote() {
 				return fmt.Errorf("failed to open subscription for remote server %s: %w", i.remote.Server, err)
@@ -216,7 +217,7 @@ func (i *Input) read(ctx context.Context) {
 				i.Logger().Error("Failed to re-establish remote session", zap.String("server", i.remote.Server), zap.Error(err))
 				return
 			}
-			if err := i.subscription.Open(i.startAt, uintptr(i.remoteSessionHandle), i.channel, i.bookmark); err != nil {
+			if err := i.subscription.Open(i.startAt, uintptr(i.remoteSessionHandle), i.channel, i.query, i.bookmark); err != nil {
 				i.Logger().Error("Failed to re-open subscription for remote server", zap.String("server", i.remote.Server), zap.Error(err))
 				return
 			}


### PR DESCRIPTION
#### Description

```yaml
receivers:
  windowseventlog/query:
    raw: true
    query: |
      <QueryList>
        <Query Id="0">
          <Select Path="Application">*[System[Provider[@Name='foo']]]</Select>
          <Select Path="Application">*[System[Provider[@Name='bar']]]</Select>
        </Query>
      </QueryList>

processors:
  resource:
    attributes:
    - key: marker
      value: axoflow-otelcol-agent
      action: upsert
exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    logs/query:
      receivers: [windowseventlog/query]
      processors: [resource]
      exporters: [debug]
```


<!--Describe what testing was performed and which tests were added.-->
#### Testing
Manual tests using `eventcreate.exe`

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
