### PR TITLE
fix(etwreceiver): make buffer_size optional

### DIFF
--- a/receiver/etwreceiver/config.go
+++ b/receiver/etwreceiver/config.go
@@ -79,7 +79,7 @@ type WindowsEtwConfig struct {
 	// See https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties
 	// Kilobytes of memory allocated for each event tracing session buffer.
 	// The minimum buffer size is 4 (4KB). The maximum buffer size is 16384 (16MB).
-	BufferSize uint32 `mapstructure:"buffer_size"`
+	BufferSize *uint32 `mapstructure:"buffer_size"`
 	// Minimum number of buffers reserved for the tracing session's buffer pool.
 	MinimumBuffers uint32 `mapstructure:"minimum_buffers"`
 	// Maximum number of buffers to be allocated for the tracing session's buffer pool.

--- a/receiver/etwreceiver/config_windows.go
+++ b/receiver/etwreceiver/config_windows.go
@@ -17,10 +17,10 @@ func (c *WindowsEtwConfig) Validate() error {
 	if _, err := TraceLevelFromString(c.Level); err != nil {
 		return err
 	}
-	if c.BufferSize < ETWReceiverMinimumBufferSize {
+	if c.BufferSize != nil && *c.BufferSize < ETWReceiverMinimumBufferSize {
 		return fmt.Errorf("buffer_size must be at least %v (in KB)", ETWReceiverMinimumBufferSize)
 	}
-	if c.BufferSize > ETWReceiverMaximumBufferSize {
+	if c.BufferSize != nil && *c.BufferSize > ETWReceiverMaximumBufferSize {
 		return fmt.Errorf("buffer_size must be at most %v (in KB)", ETWReceiverMaximumBufferSize)
 	}
 	return nil

--- a/receiver/etwreceiver/receiver_windows.go
+++ b/receiver/etwreceiver/receiver_windows.go
@@ -125,8 +125,8 @@ func newEtwReceiver(_ context.Context, cfg *WindowsEtwConfig, consumer consumer.
 		etw.WithMatchKeywords(cfg.MatchAnyKeywords, cfg.MatchAllKeywords),
 	}
 
-	if cfg.BufferSize != 0 {
-		sessionOpts = append(sessionOpts, etw.WithBufferSize(cfg.BufferSize))
+	if cfg.BufferSize != nil {
+		sessionOpts = append(sessionOpts, etw.WithBufferSize(*cfg.BufferSize))
 	}
 
 	if cfg.MinimumBuffers != 0 {


### PR DESCRIPTION
Without this if the supposedly optional field was not present the validation logic would stop the collector from starting up. 